### PR TITLE
Fixed the "missed" count in timerfd example

### DIFF
--- a/timerfd.c
+++ b/timerfd.c
@@ -57,7 +57,9 @@ static void wait_period(struct periodic_info *info)
 		return;
 	}
 
-	info->wakeups_missed += missed;
+	/* "missed" should always be >= 1, but just to be sure, check it is not 0 anyway */
+	if (missed > 0)
+		info->wakeups_missed += (missed - 1);
 }
 
 static int thread_1_count;


### PR DESCRIPTION
Hi Chris,

Thanks for the blog topic about timerfd. It helps me a lot!

I notice you already provided a fix in your blog post regarding the "missed" count in timerfd example. It seems the example in the GitHub is not updated accordingly.

In fact, I am still not quite understand your comments in your blog hope that you can help: "when you read, the value is a count of the timer events since the last one, which should be 1":
* Does this mean that value 1 actually means correctly fired timer events?
* If value is 0, that means the timer events is missed. Then, should we say this below instead?
`
	if (missed == 0)
		info->wakeups_missed +=1;
`

Cheers,
Paul